### PR TITLE
Support type export

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
           tag: ${{ steps.package-version.outputs.current-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: test
+        run: yarn test
       - name: build lib
         run: yarn build && yarn build:tool
       - name: publish to npm

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.36",
+  "version": "0.0.37",
   "name": "next-zod-router",
   "packageManager": "yarn@3.4.1",
   "bin": "./tools/index.js",
@@ -26,6 +26,16 @@
       "import": "./lib/react-query.js",
       "require": "./lib/react-query.js",
       "types": "./lib/react-query.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "swr": [
+        "./lib/swr.d.ts"
+      ],
+      "react-query": [
+        "./lib/react-query.d.ts"
+      ]
     }
   },
   "devDependencies": {

--- a/src/react-query.ts
+++ b/src/react-query.ts
@@ -7,7 +7,7 @@ type GetOptions<T extends keyof GetQuery> = {
   requestInit?: Omit<RequestInit, "body">;
 }
 
-export function useQueryClient<T extends keyof GetQuery>(key: T, options: GetOptions<T>) {
+export function useQueryClient<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
   const { data, ...rest } = useQuery([key, 'get', options], () => client.get(key, options));
   return {
     ...rest,

--- a/src/react-query.ts
+++ b/src/react-query.ts
@@ -7,7 +7,7 @@ type GetOptions<T extends keyof GetQuery> = {
   requestInit?: Omit<RequestInit, "body">;
 }
 
-export function useQueryClient<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
+export function useClientQuery<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
   const { data, ...rest } = useQuery([key, 'get', options], () => client.get(key, options));
   return {
     ...rest,

--- a/src/swr.ts
+++ b/src/swr.ts
@@ -7,7 +7,7 @@ type GetOptions<T extends keyof GetQuery> = {
   requestInit?: Omit<RequestInit, "body">;
 }
 
-export function useSWRClient<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
+export function useClientSWR<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
   const { data, ...rest } = useSWR([key, 'get', options], () => client.get(key, options));
   return {
     ...rest,

--- a/src/swr.ts
+++ b/src/swr.ts
@@ -7,7 +7,7 @@ type GetOptions<T extends keyof GetQuery> = {
   requestInit?: Omit<RequestInit, "body">;
 }
 
-export function useSWRClient<T extends keyof GetQuery>(key: T, options: GetOptions<T>) {
+export function useSWRClient<T extends keyof GetQuery>(key: T, options?: GetOptions<T>) {
   const { data, ...rest } = useSWR([key, 'get', options], () => client.get(key, options));
   return {
     ...rest,


### PR DESCRIPTION
You can now install like below

```ts
import { useClientQuery } from 'next-zod-router/react-query'